### PR TITLE
feat(email): add SMTPEmailService with libcurl-based delivery

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,8 +1,9 @@
 [requires]
 drogon/1.9.10
+libcurl/8.17.0
 argon2/20190702
 
-[options]
+[options]con
 drogon/*:with_orm=True
 drogon/*:with_postgres=True
 

--- a/config.json
+++ b/config.json
@@ -25,6 +25,18 @@
     },
     "profiling": {
       "enabled": true
+    },
+    "email": {
+      "enabled": true,
+      "smtp": {
+        "host": "smtp.gmail.com",
+        "port": 587,
+        "username": "your@email.com",
+        "password": "app_password",
+        "from": "SignalStream <noreply@signalstream.io>",
+        "use_tls": true,
+        "timeout_sec": 5
+      }
     }
   },
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 find_package(Drogon REQUIRED)
+find_package(CURL REQUIRED)
 find_package(argon2 REQUIRED CONFIG)
 
 set(REPOSITORIES
@@ -69,4 +70,5 @@ target_include_directories(${PROJECT_NAME} PRIVATE
 )
 #
 target_link_libraries(${PROJECT_NAME} PRIVATE Drogon::Drogon)
+target_link_libraries(${PROJECT_NAME} PRIVATE CURL::libcurl)
 target_link_libraries(${PROJECT_NAME} PRIVATE argon2::argon2)

--- a/server/core/EmailUtils.cpp
+++ b/server/core/EmailUtils.cpp
@@ -1,0 +1,93 @@
+#include "EmailUtils.h"
+
+#include <curl/curl.h>
+#include <sstream>
+
+namespace {
+
+    struct UploadCtx {
+        std::string payload;
+        size_t offset = 0;
+    };
+
+    size_t payloadSource(char* ptr, size_t size, size_t nmemb, void* userp) {
+        auto* ctx = static_cast<UploadCtx*>(userp);
+        size_t max = size * nmemb;
+
+        if (ctx->offset >= ctx->payload.size())
+            return 0;
+
+        size_t len = std::min(max, ctx->payload.size() - ctx->offset);
+        memcpy(ptr, ctx->payload.data() + ctx->offset, len);
+        ctx->offset += len;
+        return len;
+    }
+
+} // namespace
+
+namespace utils {
+
+    void sendEmail(
+            const std::string& host,
+            int port,
+            bool useTls,
+            const std::string& username,
+            const std::string& password,
+            const std::string& from,
+            const std::vector<std::string>& to,
+            const std::string& subject,
+            const std::string& body,
+            std::function<void(bool, const std::string&)> cb
+    ) {
+        CURL* curl = curl_easy_init();
+        if (!curl) {
+            cb(false, "Failed to init curl");
+            return;
+        }
+
+        std::ostringstream msg;
+        msg << "From: <" << from << ">\r\n";
+        for (const auto& r : to)
+            msg << "To: <" << r << ">\r\n";
+        msg << "Subject: " << subject << "\r\n";
+        msg << "\r\n";
+        msg << body << "\r\n";
+
+        UploadCtx upload{ msg.str() };
+
+        std::string url =
+                (useTls ? "smtps://" : "smtp://") +
+                host + ":" + std::to_string(port);
+
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl, CURLOPT_USERNAME, username.c_str());
+        curl_easy_setopt(curl, CURLOPT_PASSWORD, password.c_str());
+        curl_easy_setopt(curl, CURLOPT_MAIL_FROM, from.c_str());
+        curl_easy_setopt(curl, CURLOPT_READFUNCTION, payloadSource);
+        curl_easy_setopt(curl, CURLOPT_READDATA, &upload);
+        curl_easy_setopt(curl, CURLOPT_UPLOAD, 1L);
+
+        struct curl_slist* recipients = nullptr;
+        for (const auto& r : to)
+            recipients = curl_slist_append(recipients, r.c_str());
+        curl_easy_setopt(curl, CURLOPT_MAIL_RCPT, recipients);
+
+        if (useTls) {
+            curl_easy_setopt(curl, CURLOPT_USE_SSL, CURLUSESSL_ALL);
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
+        }
+
+        CURLcode res = curl_easy_perform(curl);
+
+        if (res != CURLE_OK) {
+            cb(false, curl_easy_strerror(res));
+        } else {
+            cb(true, "");
+        }
+
+        curl_slist_free_all(recipients);
+        curl_easy_cleanup(curl);
+    }
+
+} // namespace utils

--- a/server/core/EmailUtils.h
+++ b/server/core/EmailUtils.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <functional>
+
+namespace ss::utils {
+
+    void sendEmail(
+            const std::string& host,
+            int port,
+            bool useTls,
+            const std::string& username,
+            const std::string& password,
+            const std::string& from,
+            const std::vector<std::string>& to,
+            const std::string& subject,
+            const std::string& body,
+            std::function<void(bool, const std::string&)> cb
+    );
+
+}

--- a/server/core/Error.h
+++ b/server/core/Error.h
@@ -24,6 +24,9 @@ enum class ErrorType {
     // 500
     Database,
     Internal,
+
+    // 503 - Service Unavailable
+    External
 };
 
 struct AppError {
@@ -67,6 +70,10 @@ struct AppError {
     static AppError Internal(std::string msg) {
         return AppError{ErrorType::Internal, std::move(msg)};
     }
+
+    static AppError External(std::string msg) {
+        return AppError{ErrorType::External, std::move(msg)};
+    }
 };
 
 inline drogon::HttpStatusCode toHttpStatus(const AppError& err) {
@@ -85,6 +92,8 @@ inline drogon::HttpStatusCode toHttpStatus(const AppError& err) {
             return drogon::k500InternalServerError;
         case ErrorType::Internal:
             return drogon::k500InternalServerError;
+        case ErrorType::External:
+            return drogon::k503ServiceUnavailable;
         case ErrorType::None:
         default:
             return drogon::k200OK;

--- a/server/services/EmailService.h
+++ b/server/services/EmailService.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "core/Error.h"
+
+#include <string>
+#include <functional>
+
+class EmailService {
+public:
+    virtual ~EmailService() = default;
+
+    virtual void sendEmail(
+            const std::string& to,
+            const std::string& subject,
+            const std::string& body,
+            std::function<void(const AppError&)> cb
+    ) = 0;
+};

--- a/server/services/SMTPEmailService.cpp
+++ b/server/services/SMTPEmailService.cpp
@@ -1,0 +1,70 @@
+#include "SMTPEmailService.h"
+
+#include <drogon/drogon.h>
+#include <drogon/utils/Utilities.h>
+
+#include "core/Error.h"
+#include "core/ErrorLogger.h"
+#include "core/EmailUtils.h"
+
+using namespace drogon;
+
+namespace {
+
+    bool isValidEmail(const std::string& email) {
+        return email.find('@') != std::string::npos;
+    }
+
+} // namespace
+
+void SMTPEmailService::sendEmail(
+        const std::string& to,
+        const std::string& subject,
+        const std::string& body,
+        std::function<void(const AppError&)> cb
+) {
+    const auto& cfg = app().getCustomConfig();
+
+    if (!cfg.isMember("email") || !cfg["email"]["enabled"].asBool()) {
+        cb(AppError::External("Email service disabled"));
+        return;
+    }
+
+    if (!isValidEmail(to)) {
+        cb(AppError::Validation("Invalid email address"));
+        return;
+    }
+
+    const auto& smtp = cfg["email"]["smtp"];
+
+    try {
+        std::string host     = smtp["host"].asString();
+        int         port     = smtp["port"].asInt();
+        std::string username = smtp["username"].asString();
+        std::string password = smtp["password"].asString();
+        std::string from     = smtp["from"].asString();
+        bool        useTls   = smtp["use_tls"].asBool();
+
+        ss::utils::sendEmail(
+                host,
+                port,
+                useTls,
+                username,
+                password,
+                from,
+                {to},
+                subject,
+                body,
+                [cb](bool success, const std::string& error) {
+                    if (!success) {
+                        cb(AppError::External("Email delivery failed"));
+                        return;
+                    }
+
+                    cb(AppError{});
+                }
+        );
+    } catch (const std::exception& e) {
+        cb(AppError::External("Email service failure"));
+    }
+}

--- a/server/services/SMTPEmailService.h
+++ b/server/services/SMTPEmailService.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "EmailService.h"
+
+class SMTPEmailService final : public EmailService {
+public:
+    void sendEmail(
+            const std::string& to,
+            const std::string& subject,
+            const std::string& body,
+            std::function<void(const AppError&)> cb
+    ) override;
+};


### PR DESCRIPTION
- Implement utils::sendEmail using libcurl SMTP
- Support TLS and authenticated SMTP
- Centralize external email delivery logic
- Map delivery failures to AppError::External
- Keep SMTP logic out of controllers and services

# 📥 Pull Request

## 🎯 Summary
<!-- What does this PR do? Short explanation. -->
Fixes #

---

## 🧩 Changes
<!-- Bullet list of all major changes -->

- [ ]
- [ ]
- [ ]

---