### PR TITLE
feat(email): add user email lookup for broadcast delivery

### DIFF
--- a/server/controllers/AdminController.h
+++ b/server/controllers/AdminController.h
@@ -9,6 +9,7 @@ public:
         ADD_METHOD_TO(AdminController::listUsers, "/admin/users", drogon::Get, AUTH_CHAIN);
         ADD_METHOD_TO(AdminController::setRole, "/admin/set-role", drogon::Post, AUTH_CHAIN);
         ADD_METHOD_TO(AdminController::listModerators, "/admin/moderators", drogon::Get, AUTH_CHAIN);
+        ADD_METHOD_TO(AdminController::broadcastEmail, "/admin/email/broadcast", drogon::Post, AUTH_CHAIN);
         ADD_METHOD_TO(AdminController::health, "/admin/health", drogon::Get, PUBLIC);
     METHOD_LIST_END
 
@@ -28,6 +29,11 @@ public:
     );
 
     static void health(
+            const drogon::HttpRequestPtr& req,
+            std::function<void(const drogon::HttpResponsePtr&)>&& cb
+    );
+
+    static void broadcastEmail(
             const drogon::HttpRequestPtr& req,
             std::function<void(const drogon::HttpResponsePtr&)>&& cb
     );

--- a/server/repositories/UserRepository.cpp
+++ b/server/repositories/UserRepository.cpp
@@ -114,6 +114,28 @@ void UserRepository::listAllUsers(
     );
 }
 
+void UserRepository::listActiveEmails(
+        const drogon::orm::DbClientPtr& client,
+        const std::function<void(const std::vector<std::string>&, const AppError&)>& cb
+) {
+    client->execSqlAsync(
+            "SELECT email FROM users WHERE email IS NOT NULL;",
+            [cb](const drogon::orm::Result& r) {
+                std::vector<std::string> emails;
+                emails.reserve(r.size());
+
+                for (const auto& row : r) {
+                    emails.push_back(row["email"].as<std::string>());
+                }
+
+                cb(emails, AppError{});
+            },
+            [cb](const std::exception_ptr&) {
+                cb({}, AppError::Database("Failed to list user emails"));
+            }
+    );
+}
+
 void UserRepository::updateRole(
         const drogon::orm::DbClientPtr& client,
         int userId,

--- a/server/repositories/UserRepository.h
+++ b/server/repositories/UserRepository.h
@@ -29,6 +29,11 @@ public:
             const std::function<void(const std::vector<UserDTO>&, const AppError&)>& cb
     );
 
+    static void listActiveEmails(
+            const drogon::orm::DbClientPtr& client,
+            const std::function<void(const std::vector<std::string>&, const AppError&)>& cb
+    );
+
     static void updateRole(
             const drogon::orm::DbClientPtr& client,
             int userId,

--- a/server/services/AdminService.h
+++ b/server/services/AdminService.h
@@ -10,18 +10,24 @@
 class AdminService {
 public:
     static void listUsers(
-            std::function<void(const std::vector<UserDTO>&, const AppError&)> cb
+            const std::function<void(const std::vector<UserDTO>&, const AppError&)>& cb
     );
 
     static void setRole(int actorId, int targetUserId, UserRole newRole,
-            std::function<void(const UserDTO&, const AppError&)> cb
+            const std::function<void(const UserDTO&, const AppError&)>& cb
     );
 
     static void listModerators(
-            std::function<void(const std::vector<UserDTO>&, const AppError&)> cb
+            const std::function<void(const std::vector<UserDTO>&, const AppError&)>& cb
     );
 
     static void health(
             const std::function<void(const HealthDTO&)>& cb
+    );
+
+    static void broadcastEmail(
+            const std::string& subject,
+            const std::string& message,
+            const std::function<void(const AppError&)>& cb
     );
 };

--- a/server/services/EmailService.h
+++ b/server/services/EmailService.h
@@ -12,4 +12,11 @@ public:
             const std::string& token,
             std::function<void(const AppError&)> cb
     );
+
+    static void broadcast(
+            const std::vector<std::string>& recipients,
+            const std::string& subject,
+            const std::string& body,
+            std::function<void(const AppError&)> cb
+    );
 };


### PR DESCRIPTION
- Add UserRepository::listActiveEmails
- Enable email broadcast to fetch recipients via repository
- Keep EmailService free of DB access
- Prepare admin broadcast email flow

# 📥 Pull Request

## 🎯 Summary
<!-- What does this PR do? Short explanation. -->
Fixes #

---

## 🧩 Changes
<!-- Bullet list of all major changes -->

- [ ]
- [ ]
- [ ]

---